### PR TITLE
Exclude additional tags from typographic enhancement.

### DIFF
--- a/lib/typogruby.rb
+++ b/lib/typogruby.rb
@@ -268,7 +268,7 @@ private
   # @return [String] input with script tags restored
   def ignore_scripts(text)
     @ignored_scripts = {}
-    modified_text = text.gsub(/<script[^>]*>.*?<\/script>/mi) do |script|
+    modified_text = text.gsub(/<(pre|code|kbd|math|script)[^>]*>.*?<\/\1>/mi) do |script|
       hash = Digest::MD5.hexdigest(script)
       @ignored_scripts[hash] = script
       hash


### PR DESCRIPTION
In addition to `script` tags, `pre`, `code`, `kbd` and `math` should be excluded from typographic enhancement. These tags are typically used to present whitespace sensitive text, or other text where typographic enhancement is not appropriate. This list is consistent with the tags excluded from SmartyPants/RubyPants.

`ignore_scripts` and `@ignore_scripts` should probably be renamed to something more descriptive.

I wasn't able to get tests running on my local box, so I couldn't commit or update tests for this fix.
