### PR TITLE
Add hairspace typographic improvement.

### DIFF
--- a/lib/typogruby.rb
+++ b/lib/typogruby.rb
@@ -195,6 +195,25 @@ module Typogruby
     end
   end
 
+  # Converts whitespace or a non-breaking space surrounding dash entities into
+  # hairspace HTML entities.
+  #
+  # @example
+  #   hairsp('One &mdash; two')
+  #   # => 'One&#8202;&mdash;&#8202;two'
+  #   hairsp('One &#8211; two')
+  #   # => 'One&#8202;&#8211;&#8202;two'
+  #   hairsp('One &ndash;&nbsp;two')
+  #   # => 'One&#8202;&ndash;&#8202;two'
+  #
+  # @param [String] text input text
+  # @return [String] input text with hairspaces around dashes
+  def hairsp(text)
+    exclude_sensitive_tags(text) do |t|
+      t.gsub(/(?:\s+|&nbsp;)(&(?:mdash|#8212|#x2014);)(?:\s+|&nbsp;)/, '&#8202;\1&#8202;')
+    end
+  end
+
   # Converts special characters (excluding HTML tags) to HTML entities.
   #
   # @example

--- a/test/test_typogruby.rb
+++ b/test/test_typogruby.rb
@@ -104,4 +104,15 @@ class TestTypogruby < Test::Unit::TestCase
       assert_equal test_string, improve(test_string)
     end
   end
+
+  def test_should_replace_whitespace_around_emdashes
+    assert_equal 'One&#8202;&mdash;&#8202;two', hairsp('One &mdash; two')
+    assert_equal 'One&#8202;&mdash;&#8202;two', hairsp('One &mdash;&nbsp;two')
+    assert_equal 'One&#8202;&#8212;&#8202;two', hairsp('One   &#8212;	two')
+    assert_equal 'One&#8202;&#x2014;&#8202;two', hairsp('One&nbsp;&#x2014;&nbsp;two')
+    assert_equal 'One &ndash; two', hairsp('One &ndash; two')
+    assert_equal 'One&mdash;two', hairsp('One&mdash;two')
+    assert_equal 'One &mdash;two', hairsp('One &mdash;two')
+    assert_equal 'One&mdash', hairsp('One&mdash')
+  end
 end


### PR DESCRIPTION
Em dashes should be set apart from adjacent characters by hairspaces. `hairsp` will apply this rule, but only to em dash entities (`&mdash;`, `&#8212;` and `&#x2014`) which are surrounded by one or more spaces, or by non-breaking space.

e.g. "foo &mdash; bar" is converted into "foo&#8202;&mdash;&#8202;bar", and there is great rejoicing.

It also works with numeric and hex representations of em dashes: `&#8212;` and `&#x2014;`, respectively.

Note that IE 6 doesn't play nice with hairspaces (or so I've heard), so I didn't add this to the default `improve` method. If you really need to support IE 6 users, don't use hairspaces :)

It's best to apply this filter after RubyPants so you can pick up the `--` conversions, so it should be used like this: `hairsp(improve(text))`.
