### PR TITLE
Ensure duplicate sensitive tags are properly rendered.

### DIFF
--- a/lib/typogruby.rb
+++ b/lib/typogruby.rb
@@ -277,7 +277,7 @@ private
       hash
     end
     yield(modified_text).gsub(/#{@exluded_sensitive_tags.keys.join('|')}/) do |h|
-      @exluded_sensitive_tags.delete(h)
+      @exluded_sensitive_tags[h]
     end
   end
 

--- a/test/test_typogruby.rb
+++ b/test/test_typogruby.rb
@@ -104,4 +104,11 @@ class TestTypogruby < Test::Unit::TestCase
       assert_equal test_string, improve(test_string)
     end
   end
+
+  def test_should_not_forget_about_duplicate_sensitive_tags
+    %w{script pre code kbd math}.each do |tag_name|
+      test_string = "<#{tag_name}>this</#{tag_name}>==<#{tag_name}>this</#{tag_name}>"
+      assert_equal test_string, improve(test_string)
+    end
+  end
 end


### PR DESCRIPTION
Currently, using two sensitive tags with identical content in the same document will result in the second one being replaced by an empty string. This is not ideal.

This fix keeps duplicate sensitive tags from being forgotten after the first instance has been replaced.
