### PR TITLE
Add head to the excluded elements

### DIFF
--- a/lib/typogruby.rb
+++ b/lib/typogruby.rb
@@ -291,7 +291,7 @@ private
   end
 
   # Array of all the senstive tags that should be ignored by all the text filters.
-  EXCLUDED_TAGS  = %w{pre code kbd math script}
+  EXCLUDED_TAGS  = %w{head pre code kbd math script}
 
   extend self
 end

--- a/test/test_typogruby.rb
+++ b/test/test_typogruby.rb
@@ -35,6 +35,7 @@ class TestTypogruby < Test::Unit::TestCase
     assert_equal 'A message from <span class="caps">2KU2</span> with digits', caps("A message from 2KU2 with digits")
     assert_equal 'Dotted caps followed by spaces should never include them in the wrap <span class="caps">D.O.T.</span>   like so.', caps("Dotted caps followed by spaces should never include them in the wrap D.O.T.   like so.")
     assert_equal 'Caps in attributes (<span title="Example CAPS">example</span>) should be ignored', caps('Caps in attributes (<span title="Example CAPS">example</span>) should be ignored')
+    assert_equal '<head><title>CAPS Example</title></head>', caps('<head><title>CAPS Example</title></head>')
   end
 
   def test_should_not_break_caps_with_apostrophes


### PR DESCRIPTION
Typogruby should not apply any filters within the head of a page.

This change adds head by default to the excluded elements and adds
a test case for the specific bug where I ran into this.

(Thanks to @bobthecow for quickly suggesting how to fix this.)
