### PR TITLE
Added textarea to excluded tags

### DIFF
--- a/lib/typogruby.rb
+++ b/lib/typogruby.rb
@@ -291,7 +291,7 @@ private
   end
 
   # Array of all the senstive tags that should be ignored by all the text filters.
-  EXCLUDED_TAGS  = %w{head pre code kbd math script}
+  EXCLUDED_TAGS  = %w{head pre code kbd math script textarea}
 
   extend self
 end

--- a/test/test_typogruby.rb
+++ b/test/test_typogruby.rb
@@ -89,6 +89,7 @@ class TestTypogruby < Test::Unit::TestCase
   def test_should_ignore_widows_in_special_tags
     assert_equal '<div>Divs get no love!</div>', widont('<div>Divs get no love!</div>')
     assert_equal '<pre>Neither do PREs</pre>', widont('<pre>Neither do PREs</pre>')
+    assert_equal '<textarea>nor text in textarea</textarea>', widont('<textarea>nor text in textarea</textarea>')
     assert_equal "<script>\nreturn window;\n</script>", widont("<script>\nreturn window;\n</script>")
     assert_equal '<div><p>But divs with paragraphs&nbsp;do!</p></div>', widont('<div><p>But divs with paragraphs do!</p></div>')
   end


### PR DESCRIPTION
HTML textarea is also a sensitive tag which should be ignored when making replacements.
