### PR TITLE
Add entities(text) to main improve(text) function

### DIFF
--- a/lib/typogruby.rb
+++ b/lib/typogruby.rb
@@ -216,23 +216,25 @@ module Typogruby
   # @return [String] input text with all special characters converted to
   #   HTML entities.
   def entities(text)
-    o = ''
-    text.scan(/(?x)
+    exclude_sensitive_tags(text) do |t|
+      o = ''
+      t.scan(/(?x)
 
-        ( <\?(?:[^?]*|\?(?!>))*\?>
-        | <!-- (?m:.*?) -->
-        | <\/? (?i:a|abbr|acronym|address|applet|area|b|base|basefont|bdo|big|blockquote|body|br|button|caption|center|cite|code|col|colgroup|dd|del|dfn|dir|div|dl|dt|em|fieldset|font|form|frame|frameset|h1|h2|h3|h4|h5|h6|head|hr|html|i|iframe|img|input|ins|isindex|kbd|label|legend|li|link|map|menu|meta|noframes|noscript|object|ol|optgroup|option|p|param|pre|q|s|samp|script|select|small|span|strike|strong|style|sub|sup|table|tbody|td|textarea|tfoot|th|thead|title|tr|tt|u|ul|var)\b
-            (?:[^>"']|"[^"]*"|'[^']*')*
-          >
-        | &(?:[a-zA-Z0-9]+|\#[0-9]+|\#x[0-9a-fA-F]+);
-        )
-        |([^<&]+|[<&])
+          ( <\?(?:[^?]*|\?(?!>))*\?>
+          | <!-- (?m:.*?) -->
+          | <\/? (?i:a|abbr|acronym|address|applet|area|b|base|basefont|bdo|big|blockquote|body|br|button|caption|center|cite|code|col|colgroup|dd|del|dfn|dir|div|dl|dt|em|fieldset|font|form|frame|frameset|h1|h2|h3|h4|h5|h6|head|hr|html|i|iframe|img|input|ins|isindex|kbd|label|legend|li|link|map|menu|meta|noframes|noscript|object|ol|optgroup|option|p|param|pre|q|s|samp|script|select|small|span|strike|strong|style|sub|sup|table|tbody|td|textarea|tfoot|th|thead|title|tr|tt|u|ul|var)\b
+              (?:[^>"']|"[^"]*"|'[^']*')*
+            >
+          | &(?:[a-zA-Z0-9]+|\#[0-9]+|\#x[0-9a-fA-F]+);
+          )
+          |([^<&]+|[<&])
 
-      /x) do |tag, text|
-      o << tag.to_s
-      o << encode(text.to_s)
+        /x) do |tag, t|
+        o << tag.to_s
+        o << encode(t.to_s)
+      end
+      o
     end
-    o
   end
 
   # main function to do all the functions from the method.
@@ -240,7 +242,7 @@ module Typogruby
   # @param [String] text input text
   # @return [String] input text with all filters applied
   def improve(text)
-    initial_quotes(caps(smartypants(widont(amp(text)))))
+    initial_quotes(entities(caps(smartypants(widont(amp(text))))))
   end
 
 private

--- a/test/test_typogruby.rb
+++ b/test/test_typogruby.rb
@@ -67,7 +67,7 @@ class TypogrubyTest < Minitest::Test
   end
 
   def test_should_apply_all_filters
-    assert_equal '<h2><span class="dquo">&#8220;</span>Jayhawks&#8221; <span class="amp">&amp;</span> <span class="caps">KU</span> fans act extremely&nbsp;obnoxiously</h2>', improve('<h2>"Jayhawks" & KU fans act extremely obnoxiously</h2>')
+    assert_equal '<h2><span class="dquo">&#8220;</span>J&auml;yhawks&#8221; <span class="amp">&amp;</span> <span class="caps">KU</span> fans act extremely&nbsp;obnoxiously</h2>', improve('<h2>"Jäyhawks" & KU fans act extremely obnoxiously</h2>')
   end
 
   def test_should_prevent_widows


### PR DESCRIPTION
This resolves two issues with entity functionality:

1. Added entities(text) to the improve(text) main function. This will
result in
special characters being replaced with their corresponding entities
along with
all the other filters in the default mode, as promised.
2. Added exclude_sensitive_tags(text) block to entities(text). This
will result
in special characters NOT being replaced with their corresponding
entities if
they're enclosed within excluded tags. Discovered this omission when
the fix
above broke the test_should_leave_sensitive_tags_alone and
test_should_not_forget_about_duplicate_sensitive_tags tests.

Also tweaked the test_should_apply_all_filters input and output to
include a
special character.