### PR TITLE
Fix bin to include :entities

### DIFF
--- a/bin/typogruby
+++ b/bin/typogruby
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'typogruby'
 require 'optparse'
 
-operations = [:smartypants, :initial_quotes, :amp, :widont, :caps]
+operations = [:smartypants, :entities, :initial_quotes, :amp, :widont, :caps]
 explicit_on = []
 explicit_off = []
 output_filename = nil


### PR DESCRIPTION
This extends the prior fix to include entity functionality to the
default flow to the command-line bin file:

Added :entities to the operations array. This will result in special
characters being replaced with their corresponding entities along with
all the other filters in the default mode when using the command-line,
as promised.

Apologies for overlooking this in the previous PR!